### PR TITLE
Migrate from deprecated eslint option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,7 @@
   "eslint.options": {
     "configFile": ".eslintrc.js"
   },
-  "eslint.autoFixOnSave": true
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
According to https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint the _**eslint.autoFixOnSave** setting is now deprecated and can safely be removed_