### PR TITLE
fix: detect container when running via podman

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -7,7 +7,7 @@ args=""
 start_task="run-only"
 
 is_container() {
-  if [ -f /.dockerenv ]; then
+  if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
     return 0
   fi
 

--- a/run-app.sh
+++ b/run-app.sh
@@ -7,7 +7,11 @@ args=""
 start_task="run-only"
 
 is_container() {
-  if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+  if [ -f /.dockerenv ]; then
+    return 0
+  fi
+
+  if [ -f /run/.containerenv ]; then
     return 0
   fi
 

--- a/src/platform.js
+++ b/src/platform.js
@@ -84,7 +84,7 @@ function getArchitecture() {
 }
 
 /**
- * Determine whether or not we're running inside a contianer (e.g. Docker).
+ * Determine whether or not we're running inside a container (e.g. Docker).
  */
 function isContainer() {
   return fs.existsSync('/.dockerenv') ||

--- a/src/platform.js
+++ b/src/platform.js
@@ -84,10 +84,11 @@ function getArchitecture() {
 }
 
 /**
- * Determine whether or not we're running inside Docker.
+ * Determine whether or not we're running inside a contianer (e.g. Docker).
  */
-function isDocker() {
+function isContainer() {
   return fs.existsSync('/.dockerenv') ||
+    fs.existsSync('/run/.containerenv') ||
     (fs.existsSync('/proc/1/cgroup') &&
      fs.readFileSync('/proc/1/cgroup').indexOf(':/docker/') >= 0) ||
     fs.existsSync('/pantavisor');
@@ -137,7 +138,7 @@ module.exports = {
   getNodeVersion,
   getOS,
   getPythonVersions,
-  isDocker,
+  isContainer,
   NotImplementedError,
 };
 

--- a/src/platforms/linux-debian.js
+++ b/src/platforms/linux-debian.js
@@ -31,9 +31,9 @@ function getSelfUpdateStatus() {
 function getNtpStatus() {
   const platform = require('../platform');
 
-  // Inside Docker containers, we just assume the time is synchronized by the
-  // host.
-  if (platform.isDocker()) {
+  // Inside containers (e.g. Docker), we just assume the time is synchronized
+  // by the host.
+  if (platform.isContainer()) {
     return true;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,7 @@ module.exports = {
   getGatewayUserAgent: () => {
     const primary = `webthings-gateway/${pkg.version}`;
     const secondary = `(${platform.getArchitecture()}; ${platform.getOS()})`;
-    const tertiary = platform.isDocker() ? ' (docker)' : '';
+    const tertiary = platform.isContainer() ? ' (container)' : '';
 
     return `${primary} ${secondary}${tertiary}`;
   },


### PR DESCRIPTION
According to https://docs.podman.io/en/latest/markdown/podman-run.1.html
podman creates the file `/run/.containerenv` to indicate to programs
they are running in a container.

resolves #2602