### PR TITLE
Fix floorplan positioning some things (#2380)

### DIFF
--- a/static/js/views/floorplan.js
+++ b/static/js/views/floorplan.js
@@ -294,8 +294,8 @@ const FloorplanScreen = {
     const thing = this.selectedThing;
     const x = parseFloat(thing.dataset.x);
     const y = parseFloat(thing.dataset.y);
-    const thingUrl = decodeURI(thing.dataset.href);
-    const thingId = thingUrl.split('/').pop().replace(/%2F/g, '/');
+    const thingUrl = decodeURIComponent(thing.dataset.href);
+    const thingId = thingUrl.split('/').pop();
     thing.style.cursor = '';
 
     API.setThingFloorplanPosition(thingId, x, y).then(() => {


### PR DESCRIPTION
This fixes positioning for thing ids with uncommon characters (like colons as introduced by sonos adapter) by using URI decoding symmetric to [used encoding in the global API object](https://github.com/WebThingsIO/gateway/blob/master/static/js/api.js#L348). This supersedes the simple workaround for slashes introduced before.

Should fix #605 (again)