### PR TITLE
fix single quote in wifi network name

### DIFF
--- a/src/wifi-setup.ts
+++ b/src/wifi-setup.ts
@@ -12,7 +12,7 @@ import {WirelessNetwork} from './platforms/types';
 
 const hbs = expressHandlebars.create({
   helpers: {
-    escapeQuotes: (str: string) => `${str}`.replace(/'/, '\\\''),
+    escapeQuotes: (str: string) => `${str}`.replace(/"/g, '\"'),
   },
   defaultLayout: undefined, // eslint-disable-line no-undefined
   layoutsDir: Constants.VIEWS_PATH,

--- a/src/wifi-setup.ts
+++ b/src/wifi-setup.ts
@@ -12,7 +12,7 @@ import {WirelessNetwork} from './platforms/types';
 
 const hbs = expressHandlebars.create({
   helpers: {
-    escapeQuotes: (str: string) => `${str}`.replace(/"/g, '\"'),
+    escapeQuotes: (str: string) => `${str}`.replace(/"/g, '\\"'),
   },
   defaultLayout: undefined, // eslint-disable-line no-undefined
   layoutsDir: Constants.VIEWS_PATH,


### PR DESCRIPTION
This handlebars helper that escapes the wifi network name operates on single quotes, but is only used inside double quotes. Additionally, it had an extra backslash, and because the regex was missing a `g`, it would not work as intended if there was a second single quote.

I was not able to test this code because I don't know the steps involved in making a pi image from source, but I did make sure the regex works.