### PR TITLE
Add "show on floorplan" option to edit thing page

### DIFF
--- a/src/controllers/things_controller.ts
+++ b/src/controllers/things_controller.ts
@@ -381,6 +381,8 @@ function build(): express.Router {
     try {
       if (request.body.hasOwnProperty('floorplanX') && request.body.hasOwnProperty('floorplanY')) {
         description = await thing.setCoordinates(request.body.floorplanX, request.body.floorplanY);
+      } else if (request.body.hasOwnProperty('floorplanVisibility')) {
+        description = await thing.setFloorplanVisibility(request.body.floorplanVisibility);
       } else if (request.body.hasOwnProperty('layoutIndex')) {
         description = await thing.setLayoutIndex(request.body.layoutIndex);
       } else {

--- a/src/controllers/things_controller.ts
+++ b/src/controllers/things_controller.ts
@@ -381,8 +381,6 @@ function build(): express.Router {
     try {
       if (request.body.hasOwnProperty('floorplanX') && request.body.hasOwnProperty('floorplanY')) {
         description = await thing.setCoordinates(request.body.floorplanX, request.body.floorplanY);
-      } else if (request.body.hasOwnProperty('floorplanVisibility')) {
-        description = await thing.setFloorplanVisibility(request.body.floorplanVisibility);
       } else if (request.body.hasOwnProperty('layoutIndex')) {
         description = await thing.setLayoutIndex(request.body.layoutIndex);
       } else {
@@ -436,6 +434,10 @@ function build(): express.Router {
         response.status(500).send(`Failed to update thing ${thingId}: ${e}`);
         return;
       }
+    }
+
+    if (request.body.hasOwnProperty('floorplanVisibility')) {
+      await thing.setFloorplanVisibility(request.body.floorplanVisibility);
     }
 
     let description;

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -42,6 +42,7 @@ export interface ThingDescription {
   actions: Record<string, ActionSchema>;
   events: Record<string, EventSchema>;
   links: Link[];
+  floorplanVisibility: boolean;
   floorplanX: number;
   floorplanY: number;
   layoutIndex: number;
@@ -91,6 +92,8 @@ export default class Thing extends EventEmitter {
   private connected: boolean;
 
   private eventsDispatched: Event[];
+
+  private floorplanVisibility: boolean;
 
   private floorplanX: number;
 
@@ -166,6 +169,7 @@ export default class Thing extends EventEmitter {
         this.properties[propertyName] = property;
       }
     }
+    this.floorplanVisibility = description.floorplanVisibility;
     this.floorplanX = description.floorplanX;
     this.floorplanY = description.floorplanY;
     this.layoutIndex = description.layoutIndex;
@@ -309,6 +313,20 @@ export default class Thing extends EventEmitter {
 
   getProperties(): Record<string, PropertySchema> {
     return this.properties;
+  }
+
+  /**
+   * Set the visibility of a Thing on the floorplan.
+   *
+   * @param {boolean} visibility Whether or not to include in the floorplan view.
+   * @return {Promise} A promise which resolves with the description set.
+   */
+  setFloorplanVisibility(visibility: boolean): Promise<ThingDescription> {
+    this.floorplanVisibility = visibility;
+    return Database.updateThing(this.id, this.getDescription()).then((descr) => {
+      this.emit(Constants.MODIFIED);
+      return descr;
+    });
   }
 
   /**
@@ -537,6 +555,7 @@ export default class Thing extends EventEmitter {
       actions: this.actions,
       events: this.events,
       links: JSON.parse(JSON.stringify(this.links)),
+      floorplanVisibility: this.floorplanVisibility,
       floorplanX: this.floorplanX,
       floorplanY: this.floorplanY,
       layoutIndex: this.layoutIndex,

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -435,12 +435,14 @@ describe('things/', function () {
 
   it('set floorplanVisibility of a thing', async () => {
     await addDevice();
+    const UPDATED_DESCRIPTION = JSON.parse(JSON.stringify(TEST_THING));
+    UPDATED_DESCRIPTION.floorplanVisibility = false;
     const on = await chai
       .request(server)
-      .patch(`${Constants.THINGS_PATH}/test-1`)
+      .put(`${Constants.THINGS_PATH}/test-1`)
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
-      .send({ floorplanVisibility: false });
+      .send(UPDATED_DESCRIPTION);
 
     expect(on.status).toEqual(200);
     expect(on.body).toHaveProperty('floorplanVisibility');

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -433,6 +433,20 @@ describe('things/', function () {
     expect(err.status).toEqual(400);
   });
 
+  it('set floorplanVisibility of a thing', async () => {
+    await addDevice();
+    const on = await chai
+      .request(server)
+      .patch(`${Constants.THINGS_PATH}/test-1`)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send({ floorplanVisibility: false });
+
+    expect(on.status).toEqual(200);
+    expect(on.body).toHaveProperty('floorplanVisibility');
+    expect(on.body.floorplanVisibility).toEqual(false);
+  });
+
   it('set x and y coordinates of a thing', async () => {
     await addDevice();
     const on = await chai

--- a/static/css/context-menu.css
+++ b/static/css/context-menu.css
@@ -147,3 +147,27 @@
     padding-bottom: 1rem;
   }
 }
+
+.show-on-floorplan {
+  margin-bottom: 1.5rem;
+}
+
+.show-on-floorplan input {
+  position: absolute;
+  left: -1000em;
+}
+
+.show-on-floorplan input[type='checkbox'] + label::before {
+  content: '';
+  display: inline-block;
+  width: 3rem;
+  height: 3rem;
+  background: url(/images/checkbox-sprite.png) no-repeat 0 0;
+  background-size: 3rem auto;
+  transform: translateY(25%);
+  padding-left: 5px;
+}
+
+.show-on-floorplan input[type='checkbox']:checked + label::before {
+  background-position: 0 -3rem;
+}

--- a/static/css/context-menu.css
+++ b/static/css/context-menu.css
@@ -162,7 +162,7 @@
   display: inline-block;
   width: 3rem;
   height: 3rem;
-  background: url(/images/checkbox-sprite.png) no-repeat 0 0;
+  background: url('/images/checkbox-sprite.png') no-repeat 0 0;
   background-size: 3rem auto;
   transform: translateY(25%);
   padding-left: 5px;

--- a/static/fluent/de/main.ftl
+++ b/static/fluent/de/main.ftl
@@ -249,6 +249,7 @@ add-thing-cancel = Abbrechen
 context-menu-choose-icon = Symbol auswählen…
 context-menu-save = Speichern
 context-menu-remove = Löschen
+context-menu-show-on-floorplan = Im Raumplan anzeigen?
 
 ## Capabilities
 

--- a/static/fluent/en-US/main.ftl
+++ b/static/fluent/en-US/main.ftl
@@ -249,6 +249,7 @@ add-thing-cancel = Cancel
 context-menu-choose-icon = Choose icon…
 context-menu-save = Save
 context-menu-remove = Remove
+context-menu-show-on-floorplan = Show in floorplan view?
 
 ## Capabilities
 

--- a/static/index.html
+++ b/static/index.html
@@ -860,6 +860,10 @@
             >
             </label>
             <span id="edit-thing-label" class="hidden"></span>
+            <div class="checkbox show-on-floorplan">
+              <input type="checkbox" required="" id="show-on-floorplan-checkbox">
+              <label for="show-on-floorplan-checkbox" data-l10n-id="context-menu-show-on-floorplan"></label>
+            </div>
           </div>
           <button
             id="edit-thing-save-button"

--- a/static/index.html
+++ b/static/index.html
@@ -861,8 +861,11 @@
             </label>
             <span id="edit-thing-label" class="hidden"></span>
             <div class="checkbox show-on-floorplan">
-              <input type="checkbox" required="" id="show-on-floorplan-checkbox">
-              <label for="show-on-floorplan-checkbox" data-l10n-id="context-menu-show-on-floorplan"></label>
+              <input type="checkbox" required="" id="show-on-floorplan-checkbox" />
+              <label
+                for="show-on-floorplan-checkbox"
+                data-l10n-id="context-menu-show-on-floorplan"
+              ></label>
             </div>
           </div>
           <button

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -35,6 +35,7 @@ const ContextMenu = {
     this.customIcon = document.getElementById('edit-thing-custom-icon');
     this.customIconInput = document.getElementById('edit-thing-custom-icon-input');
     this.customIconLabel = document.getElementById('edit-thing-custom-icon-label');
+    this.showOnFloorplanCheckbox = document.getElementById('show-on-floorplan-checkbox');
     this.label = document.getElementById('edit-thing-label');
     this.removeButton = document.getElementById('remove-thing-button');
     this.logoutForm = document.getElementById('logout');
@@ -223,6 +224,8 @@ const ContextMenu = {
     if (this.thingType.options.length > 0) {
       capability = this.thingType.options[this.thingType.selectedIndex].value;
     }
+
+    console.log('TODO', this.showOnFloorplanCheckbox.checked);
 
     const body = { title, selectedCapability: capability };
 

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -90,6 +90,7 @@ const ContextMenu = {
         this.saveButton.disabled = false;
         this.customIconInput.disabled = false;
         this.titleInput.value = e.detail.thingTitle;
+        this.showOnFloorplanCheckbox.checked = e.detail.floorplanVisibility;
         this.thingType.innerHTML = '';
 
         if (!e.detail.selectedCapability || e.detail.selectedCapability === 'Custom') {
@@ -225,9 +226,9 @@ const ContextMenu = {
       capability = this.thingType.options[this.thingType.selectedIndex].value;
     }
 
-    console.log('TODO', this.showOnFloorplanCheckbox.checked);
+    const floorplanVisibility = this.showOnFloorplanCheckbox.checked;
 
-    const body = { title, selectedCapability: capability };
+    const body = { title, floorplanVisibility, selectedCapability: capability };
 
     if (capability === 'Custom' && this.iconData) {
       body.iconData = this.iconData;

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -83,6 +83,7 @@ class Thing {
     }
 
     this.selectedCapability = description.selectedCapability;
+    this.floorplanVisibility = 'floorplanVisibility' in description !== false;
     this.layoutIndex = description.layoutIndex;
     this.iconHref = description.iconHref || '';
     this.baseIcon = opts.baseIcon || fluent.getMessage('thing-icons-thing-src');
@@ -737,6 +738,7 @@ class Thing {
       detail: {
         thingId: this.id,
         thingTitle: this.title,
+        floorplanVisibility: this.floorplanVisibility,
         thingIcon: this.baseIcon,
         action: 'edit',
         capabilities: this['@type'],

--- a/static/js/views/floorplan.js
+++ b/static/js/views/floorplan.js
@@ -84,6 +84,10 @@ const FloorplanScreen = {
     let y = this.ORIGIN_Y;
     things.forEach((description, thingId) => {
       App.gatewayModel.getThingModel(thingId).then((thingModel) => {
+        if (description.floorplanVisibility === false) {
+          return;
+        }
+
         if (!description.floorplanX || !description.floorplanY) {
           description.floorplanX = x;
           description.floorplanY = y;


### PR DESCRIPTION
This allows to hide a thing from the floorplan view via its edit page, as suggested in #2357.

![image](https://user-images.githubusercontent.com/44091658/120872123-038cdd00-c59e-11eb-9186-40e242ca1e86.png)
