### PR TITLE
Tweak recommended dependencies to avoid PageKite issue discovered in #2817

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ $ sudo apt install \
     libudev-dev \
     libusb-1.0-0-dev \
     pkg-config \
-    python-pip \
+    python-six \
     python3-pip
-$ sudo -H python2 -m pip install six
 $ sudo -H python3 -m pip install git+https://github.com/WebThingsIO/gateway-addon-python#egg=gateway_addon
 ```
 


### PR DESCRIPTION
I discovered that #2817 reproduces when building from source too if python2 is not installed, because PageKite depends on python2.

The current list of recommended dependencies includes python-pip which doesn't exist on Ubuntu. I propose removing this and instead adding "python-six" which exists on both Debian and Ubuntu and should pull in python2 as well, then removing the pip install of python-six.

I'm not sure how different the Debian package of python-six is to the pip one, but this seemed to work for me. We should separately figure out why the Debian package doesn't seem to be pulling python2 in as a dependency in #2817.