### PR TITLE
W3C compliant properties protocol binding

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -273,7 +273,12 @@ function createApp(isSecure: boolean): express.Application {
       extended: false,
     })
   );
-  app.use(bodyParser.json({ limit: '1mb' }));
+  app.use(
+    bodyParser.json({
+      limit: '1mb',
+      strict: false,
+    })
+  );
 
   // Use fileUpload to handle multi-part uploads
   app.use(fileUpload());

--- a/src/controllers/things_controller.ts
+++ b/src/controllers/things_controller.ts
@@ -324,9 +324,7 @@ function build(): express.Router {
     const propertyName = request.params.propertyName;
     try {
       const value = await Things.getThingProperty(thingId, propertyName);
-      const result: Record<string, unknown> = {};
-      result[propertyName] = value;
-      response.status(200).json(result);
+      response.status(200).json(value);
     } catch (err) {
       response.status(err.code).send(err.message);
     }
@@ -338,17 +336,14 @@ function build(): express.Router {
   controller.put('/:thingId/properties/:propertyName', async (request, response) => {
     const thingId = request.params.thingId;
     const propertyName = request.params.propertyName;
-    if (!request.body || typeof request.body[propertyName] === 'undefined') {
-      response.status(400).send('Invalid property name');
+    if (typeof request.body === 'undefined') {
+      response.sendStatus(400);
       return;
     }
-    const value = request.body[propertyName];
+    const value = request.body;
     try {
-      const updatedValue = await Things.setThingProperty(thingId, propertyName, value);
-      const result = {
-        [propertyName]: updatedValue,
-      };
-      response.status(200).json(result);
+      await Things.setThingProperty(thingId, propertyName, value);
+      response.sendStatus(204);
     } catch (e) {
       console.error('Error setting property:', e);
       response.status(e.code || 500).send(e.message);

--- a/src/test/browser/test-utils.ts
+++ b/src/test/browser/test-utils.ts
@@ -71,8 +71,9 @@ export async function setProperty(id: string, property: string, value: unknown):
     .request(server)
     .keepOpen()
     .put(`${Constants.THINGS_PATH}/${id}/properties/${property}`)
+    .type('json')
     .set(...headerAuth(jwt))
-    .send(value);
+    .send(JSON.stringify(value));
 }
 
 export function escapeHtmlForIdClass(text: string): string {

--- a/src/test/browser/test-utils.ts
+++ b/src/test/browser/test-utils.ts
@@ -63,18 +63,16 @@ export async function getProperty<T>(id: string, property: string): Promise<T> {
     .get(`${Constants.THINGS_PATH}/${id}/properties/${property}`)
     .set('Accept', 'application/json')
     .set(...headerAuth(jwt));
-  return res.body[property];
+  return res.body;
 }
 
-export async function setProperty<T>(id: string, property: string, value: T): Promise<T> {
-  const res = await chai
+export async function setProperty(id: string, property: string, value: unknown): Promise<void> {
+  await chai
     .request(server)
     .keepOpen()
     .put(`${Constants.THINGS_PATH}/${id}/properties/${property}`)
-    .set('Accept', 'application/json')
     .set(...headerAuth(jwt))
-    .send({ [property]: value });
-  return res.body[property];
+    .send(value);
 }
 
 export function escapeHtmlForIdClass(text: string): string {

--- a/src/test/integration/logs-test.ts
+++ b/src/test/integration/logs-test.ts
@@ -78,10 +78,10 @@ describe('logs/', function () {
     const res = await chai
       .request(server)
       .put(`${Constants.THINGS_PATH}/${thingId}/properties/${propId}`)
-      .set('Accept', 'application/json')
+      .type('json')
       .set(...headerAuth(jwt))
-      .send({ [propId]: value });
-    expect(res.status).toEqual(200);
+      .send(JSON.stringify(value));
+    expect(res.status).toEqual(204);
 
     // sleep just a bit to allow events to fire in the gateway
     await sleep(200);

--- a/src/test/rules-engine/index-test.ts
+++ b/src/test/rules-engine/index-test.ts
@@ -452,9 +452,9 @@ describe('rules engine', () => {
     res = await chai
       .request(server)
       .put(`${Constants.THINGS_PATH}/${thingLight1.id}/properties/on`)
-      .set('Accept', 'application/json')
+      .type('json')
       .set(...headerAuth(jwt))
-      .send({ on: true });
+      .send(JSON.stringify(true));
 
     res = await chai
       .request(server)
@@ -463,7 +463,7 @@ describe('rules engine', () => {
       .set(...headerAuth(jwt));
 
     expect(res.status).toEqual(200);
-    expect(res.body.on).toEqual(false);
+    expect(res.body).toEqual(false);
 
     await deleteRule(ruleId);
   });
@@ -510,12 +510,12 @@ describe('rules engine', () => {
       chai
         .request(server)
         .put(`${Constants.THINGS_PATH}/${thingLight2.id}/properties/hue`)
-        .set('Accept', 'application/json')
+        .type('json')
         .set(...headerAuth(jwt))
-        .send({ hue: 150 }),
+        .send(JSON.stringify(150)),
       webSocketRead(ws, 7),
     ]);
-    expect(resPut.status).toEqual(200);
+    expect(resPut.status).toEqual(204);
 
     expect(Array.isArray(messages)).toBeTruthy();
     expect(messages.length).toEqual(7);
@@ -558,17 +558,17 @@ describe('rules engine', () => {
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
-    return res.body.on;
+    return res.body;
   }
 
   async function setOn(lightId: string, on: boolean): Promise<void> {
     const res = await chai
       .request(server)
       .put(`${Constants.THINGS_PATH}/${lightId}/properties/on`)
-      .set('Accept', 'application/json')
+      .type('json')
       .set(...headerAuth(jwt))
-      .send({ on });
-    expect(res.status).toEqual(200);
+      .send(JSON.stringify(on));
+    expect(res.status).toEqual(204);
   }
 
   it('creates and simulates an off rule', async () => {
@@ -675,10 +675,10 @@ describe('rules engine', () => {
     res = await chai
       .request(server)
       .put(`${Constants.THINGS_PATH}/light3/properties/color`)
-      .set('Accept', 'application/json')
+      .type('json')
       .set(...headerAuth(jwt))
-      .send({ color: '#00ff77' });
-    expect(res.status).toEqual(200);
+      .send(JSON.stringify('#00ff77'));
+    expect(res.status).toEqual(204);
 
     await waitForExpect(async () => {
       expect(await getOn(thingLight3.id)).toEqual(true);

--- a/static/js/api.ts
+++ b/static/js/api.ts
@@ -84,6 +84,20 @@ class API {
     });
   }
 
+  putJsonWithEmptyResponse(url: string, data: unknown): Promise<void> {
+    const opts = {
+      method: 'PUT',
+      headers: this.headers('application/json'),
+      body: JSON.stringify(data),
+    };
+
+    return fetch(url, opts).then((res) => {
+      if (!res.ok) {
+        throw new Error(`${res.status}`);
+      }
+    });
+  }
+
   patchJson(url: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {
     const opts = {
       method: 'PATCH',

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -193,9 +193,6 @@ class ThingModel extends Model {
     }
 
     const property = this.propertyDescriptions[name];
-    const payload = {
-      [name]: value,
-    };
 
     let href;
     for (const link of property.links) {
@@ -205,9 +202,11 @@ class ThingModel extends Model {
       }
     }
 
-    return API.putJson(href, payload)
-      .then((json) => {
-        this.onPropertyStatus(json);
+    return API.putJsonWithEmptyResponse(href, value)
+      .then(() => {
+        const result = {};
+        result[name] = value;
+        this.onPropertyStatus(result);
       })
       .catch((error) => {
         console.error(error);


### PR DESCRIPTION
This is a work-in-progress implementation to make the properties part of the gateway's API W3C compliant and is a partial fix to #2807.
- [x] Remove object wrapper from property API requests (to make API payloads directly match property data schema in Thing Descriptions)
- [x] Provide an empty response to set property PUT requests (to match the [properties protocol binding](https://w3c.github.io/wot-profile/#properties) of the Core Profile, which will make it easier to conform with that profile in the future)
- [x] Update the front end to consume the new API
- [ ] Fix the litany of failing integration tests as a result of changing the API