### PR TITLE
`writemultipleproperties` operation - closes #2891

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -84,6 +84,7 @@ export enum LogSeverity {
 
 export enum WoTOperation {
   READ_ALL_PROPERTIES = 'readallproperties',
+  WRITE_MULTIPLE_PROPERTIES = 'writemultipleproperties',
   SUBSCRIBE_ALL_EVENTS = 'subscribeallevents',
   UNSUBSCRIBE_ALL_EVENTS = 'unsubscribeallevents',
   QUERY_ALL_ACTIONS = 'queryallactions',

--- a/src/controllers/things_controller.ts
+++ b/src/controllers/things_controller.ts
@@ -320,6 +320,32 @@ function build(): express.Router {
   });
 
   /**
+   * Set multiple properties of a Thing.
+   */
+  controller.put('/:thingId/properties', async (request, response) => {
+    const thingId = request.params.thingId;
+    if (!(typeof request.body === 'object') || request.body === null) {
+      response.sendStatus(400);
+      return;
+    }
+    // An array of promises to set each property
+    const promises = [];
+    for (const propertyName of Object.keys(request.body)) {
+      promises.push(Things.setThingProperty(thingId, propertyName, request.body[propertyName]));
+    }
+    Promise.all(promises)
+      .then(() => {
+        // Respond with success code if all properties set successfully
+        response.sendStatus(204);
+      })
+      .catch((err) => {
+        // Otherwise send an error response
+        console.error('Error setting property:', err);
+        response.sendStatus(500);
+      });
+  });
+
+  /**
    * Get a property of a Thing.
    */
   controller.get('/:thingId/properties/:propertyName', async (request, response) => {
@@ -345,7 +371,6 @@ function build(): express.Router {
     }
     const value = request.body;
     try {
-      // Note: updatedValue may differ from value
       await Things.setThingProperty(thingId, propertyName, value);
       response.sendStatus(204);
     } catch (err) {

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -143,9 +143,15 @@ export default class Thing extends EventEmitter {
     this.eventsDispatched = [];
     this.forms = [];
 
+    let hasWriteableProperties = false;
+
     if (description.properties) {
       for (const propertyName in description.properties) {
         const property = description.properties[propertyName];
+
+        if (!(property.hasOwnProperty('readOnly') && property.readOnly == true)) {
+          hasWriteableProperties = true;
+        }
 
         if (property.hasOwnProperty('href')) {
           delete property.href;
@@ -177,9 +183,22 @@ export default class Thing extends EventEmitter {
 
       // If there are properties, add a top level form for them
       if (Object.keys(description.properties).length > 0) {
+        let ops;
+        // If there are writable properties then add readallproperties and
+        // writemultipleproperties operations as an array
+        if (hasWriteableProperties) {
+          ops = [
+            Constants.WoTOperation.READ_ALL_PROPERTIES,
+            Constants.WoTOperation.WRITE_MULTIPLE_PROPERTIES,
+          ];
+        } else {
+          // Otherwise just add readallproperties operation as a string
+          ops = Constants.WoTOperation.READ_ALL_PROPERTIES;
+        }
+
         this.forms.push({
           href: `${this.href}${Constants.PROPERTIES_PATH}`,
-          op: Constants.WoTOperation.READ_ALL_PROPERTIES,
+          op: ops,
         });
       }
     }
@@ -691,9 +710,14 @@ export default class Thing extends EventEmitter {
     this.forms = [];
     // Update properties
     this.properties = {};
+    let hasWriteableProperties = false;
     if (description.properties) {
       for (const propertyName in description.properties) {
         const property = description.properties[propertyName];
+
+        if (!(property.hasOwnProperty('readOnly') && property.readOnly == true)) {
+          hasWriteableProperties = true;
+        }
 
         if (property.hasOwnProperty('href')) {
           delete property.href;
@@ -723,9 +747,22 @@ export default class Thing extends EventEmitter {
 
       // If there are properties, add a top level form for them
       if (Object.keys(description.properties).length > 0) {
+        let ops;
+        // If there are writable properties then add readallproperties and
+        // writemultipleproperties operations as an array
+        if (hasWriteableProperties) {
+          ops = [
+            Constants.WoTOperation.READ_ALL_PROPERTIES,
+            Constants.WoTOperation.WRITE_MULTIPLE_PROPERTIES,
+          ];
+        } else {
+          // Otherwise just add readallproperties operation as a string
+          ops = Constants.WoTOperation.READ_ALL_PROPERTIES;
+        }
+
         this.forms.push({
           href: `${this.href}${Constants.PROPERTIES_PATH}`,
-          op: Constants.WoTOperation.READ_ALL_PROPERTIES,
+          op: ops,
         });
       }
     }

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -436,6 +436,54 @@ describe('things/', function () {
     expect(readOff.body).toEqual(false);
   });
 
+  it('set multiple properties of a thing', async () => {
+    // Set properties
+    await addDevice();
+    const setProperties = await chai
+      .request(server)
+      .put(`${Constants.THINGS_PATH}/test-1/properties`)
+      .type('json')
+      .set(...headerAuth(jwt))
+      .send(
+        JSON.stringify({
+          power: true,
+          percent: 42,
+        })
+      );
+
+    expect(setProperties.status).toEqual(204);
+
+    // Check that the properties were set
+    const getProperties = await chai
+      .request(server)
+      .get(`${Constants.THINGS_PATH}/test-1/properties`)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(getProperties.status).toEqual(200);
+    expect(getProperties.body.power).toEqual(true);
+    expect(getProperties.body.percent).toEqual(42);
+  });
+
+  it('fail to set multiple properties of a thing', async () => {
+    // Set properties
+    await addDevice();
+    const setProperties = await chai
+      .request(server)
+      .put(`${Constants.THINGS_PATH}/test-1/properties`)
+      .type('json')
+      .set(...headerAuth(jwt))
+      .send(
+        JSON.stringify({
+          power: true,
+          percent: 42,
+          invalidpropertyname: true,
+        })
+      );
+
+    expect(setProperties.status).toEqual(500);
+  });
+
   it('fail to set x and y coordinates of a non-existent thing', async () => {
     const err = await chai
       .request(server)

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -18,6 +18,7 @@ module.exports.WoTOperation = {
   WRITE_PROPERTY: 'writeproperty',
   INVOKE_ACTION: 'invokeaction',
   READ_ALL_PROPERTIES: 'readallproperties',
+  WRITE_MULTIPLE_PROPERTIES: 'writemultipleproperties',
   SUBSCRIBE_ALL_EVENTS: 'subscribeallevents',
   UNSUBSCRIBE_ALL_EVENTS: 'unsubscribeallevents',
   QUERY_ALL_ACTIONS: 'queryallactions',

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -44,15 +44,20 @@ class ThingModel extends Model {
 
     // Parse properties and events URLs
     for (const form of description.forms) {
-      switch (form.op) {
-        case Constants.WoTOperation.SUBSCRIBE_ALL_EVENTS:
-          this.eventsHref = new URL(form.href, this.base);
-          break;
-        case Constants.WoTOperation.READ_ALL_PROPERTIES:
-          this.propertiesHref = new URL(form.href, this.base);
-          break;
-        default:
-          break;
+      const op = form.op;
+
+      // Properties URL
+      if (
+        (typeof op === 'string' && op === Constants.WoTOperation.READ_ALL_PROPERTIES) ||
+        (Array.isArray(op) && op.includes(Constants.WoTOperation.READ_ALL_PROPERTIES))
+      ) {
+        this.propertiesHref = new URL(form.href, this.base);
+        // Events URL
+      } else if (
+        (typeof op === 'string' && op === Constants.WoTOperation.SUBSCRIBE_ALL_EVENTS) ||
+        (Array.isArray(op) && op.includes(Constants.WoTOperation.SUBSCRIBE_ALL_EVENTS))
+      ) {
+        this.eventsHref = new URL(form.href, this.base);
       }
     }
 


### PR DESCRIPTION
Implementation of the [`writemultipleproperties` operation](https://w3c.github.io/wot-profile/#writemultipleproperties) from WoT Core Profile.

Currently builds on #2897 so will need rebasing against master