### PR TITLE
`invokeaction` operation - closes #2893

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,14 @@ export enum WoTOperation {
   UNSUBSCRIBE_ALL_EVENTS = 'unsubscribeallevents',
   QUERY_ALL_ACTIONS = 'queryallactions',
 }
+
+export enum ActionStatusValues {
+  PENDING = 'pending',
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
 export interface LogMessage {
   severity: LogSeverity;
   message: string;

--- a/src/controllers/actions_controller.ts
+++ b/src/controllers/actions_controller.ts
@@ -21,18 +21,19 @@ function build(): express.Router {
    * Handle creating a new action.
    */
   controller.post('/', async (request: Request, response: Response) => {
+    console.warn('Invoking an action without the action name in the URL is deprecated');
     const keys = Object.keys(request.body);
     if (keys.length != 1) {
       const err = 'Incorrect number of parameters.';
       console.log(err, request.body);
-      response.status(400).send(err);
+      response.status(400).send();
       return;
     }
 
     const actionName = keys[0];
 
     if (!Object.prototype.hasOwnProperty.call(request.body[actionName], 'input')) {
-      response.status(400).send('Missing input');
+      response.status(400).send();
       return;
     }
 
@@ -46,7 +47,7 @@ function build(): express.Router {
         action = new Action(actionName, actionParams, thing);
       } catch (e) {
         console.error('Thing does not exist', thingId, e);
-        response.status(404).send(e);
+        response.status(404).send();
         return;
       }
     } else {
@@ -58,12 +59,12 @@ function build(): express.Router {
         await AddonManager.requestAction(thingId, action.getId(), actionName, actionParams);
       }
       await Actions.add(action);
-
-      response.status(201).json({ [actionName]: action.getDescription() });
+      response.location(action.getDescription().href);
+      response.status(201).json(action.getDescription());
     } catch (e) {
       console.error('Creating action', actionName, 'failed');
       console.error(e);
-      response.status(400).send(e);
+      response.status(400).send();
     }
   });
 
@@ -105,8 +106,8 @@ function build(): express.Router {
         action = new Action(actionName, input, thing);
       } catch (e) {
         console.error('Thing does not exist', thingId, e);
+        response.status(404).send();
         return;
-        response.status(404).send(e);
       }
     } else {
       action = new Action(actionName, input);
@@ -117,12 +118,12 @@ function build(): express.Router {
         await AddonManager.requestAction(thingId, action.getId(), actionName, input);
       }
       await Actions.add(action);
-
-      response.status(201).json({ [actionName]: action.getDescription() });
+      response.location(action.getDescription().href);
+      response.status(201).json(action.getDescription());
     } catch (e) {
-      console.error('Creating action', actionName, 'failed');
+      console.error('Creating action', actionName, 'failed.');
       console.error(e);
-      response.status(400).send(e);
+      response.status(400).send();
     }
   });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,3 +3,13 @@ export class HttpErrorWithCode extends Error {
     super(message);
   }
 }
+
+// Problem Details (https://www.rfc-editor.org/rfc/rfc7807)
+export interface ProblemDetails {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+  [key: string]: unknown;
+}

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -16,12 +16,11 @@ import { ActionDescription as AddonActionDescription, Any } from 'gateway-addon/
 import Thing from './thing';
 
 export interface ActionDescription {
-  input: Any;
   href: string;
   status: string;
   timeRequested: string;
   timeCompleted?: string;
-  error?: string;
+  error?: Record<string, unknown>;
 }
 
 export default class Action extends EventEmitter {
@@ -41,7 +40,7 @@ export default class Action extends EventEmitter {
 
   private timeCompleted: string | null;
 
-  private error: string;
+  private error: Record<string, unknown> | null;
 
   /**
    * Create a new Action
@@ -62,15 +61,14 @@ export default class Action extends EventEmitter {
       this.href = `${Constants.ACTIONS_PATH}/${name}/${this.id}`;
       this.thingId = null;
     }
-    this.status = 'created';
+    this.status = Constants.ActionStatusValues.PENDING;
     this.timeRequested = Utils.timestamp();
     this.timeCompleted = null;
-    this.error = '';
+    this.error = null;
   }
 
   getDescription(): ActionDescription {
     const description: ActionDescription = {
-      input: this.input,
       href: this.href,
       status: this.status,
       timeRequested: this.timeRequested,
@@ -96,7 +94,7 @@ export default class Action extends EventEmitter {
       return;
     }
 
-    if (newStatus === 'completed') {
+    if (newStatus === Constants.ActionStatusValues.COMPLETED) {
       this.timeCompleted = Utils.timestamp();
     }
 
@@ -145,7 +143,7 @@ export default class Action extends EventEmitter {
     return this.timeCompleted;
   }
 
-  setError(error: string): void {
+  setError(error: Record<string, unknown>): void {
     this.error = error;
   }
 }

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -10,6 +10,7 @@
 
 import Actions from './actions';
 import * as Constants from '../constants';
+import { ProblemDetails } from '../errors';
 import { EventEmitter } from 'events';
 import { Utils } from 'gateway-addon';
 import { ActionDescription as AddonActionDescription, Any } from 'gateway-addon/lib/schema';
@@ -20,7 +21,7 @@ export interface ActionDescription {
   status: string;
   timeRequested: string;
   timeCompleted?: string;
-  error?: Record<string, unknown>;
+  error?: ProblemDetails;
 }
 
 export default class Action extends EventEmitter {
@@ -40,7 +41,7 @@ export default class Action extends EventEmitter {
 
   private timeCompleted: string | null;
 
-  private error: Record<string, unknown> | null;
+  private error: ProblemDetails | null;
 
   /**
    * Create a new Action
@@ -143,7 +144,7 @@ export default class Action extends EventEmitter {
     return this.timeCompleted;
   }
 
-  setError(error: Record<string, unknown>): void {
+  setError(error: ProblemDetails): void {
     this.error = error;
   }
 }

--- a/src/test/integration/actions-test.ts
+++ b/src/test/integration/actions-test.ts
@@ -132,9 +132,6 @@ describe('actions/', () => {
     expect(res.body.length).toEqual(1);
     expect(res.body[0]).toHaveProperty('pair');
     expect(res.body[0].pair).toHaveProperty('href');
-    expect(res.body[0].pair).toHaveProperty('input');
-    expect(res.body[0].pair.input).toHaveProperty('timeout');
-    expect(res.body[0].pair.input.timeout).toEqual(60);
     expect(res.body[0].pair).toHaveProperty('status');
     expect(res.body[0].pair).toHaveProperty('timeRequested');
 
@@ -148,9 +145,6 @@ describe('actions/', () => {
     expect(res.body.length).toEqual(1);
     expect(res.body[0]).toHaveProperty('pair');
     expect(res.body[0].pair).toHaveProperty('href');
-    expect(res.body[0].pair).toHaveProperty('input');
-    expect(res.body[0].pair.input).toHaveProperty('timeout');
-    expect(res.body[0].pair.input.timeout).toEqual(60);
     expect(res.body[0].pair).toHaveProperty('status');
     expect(res.body[0].pair).toHaveProperty('timeRequested');
 
@@ -163,9 +157,6 @@ describe('actions/', () => {
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty('pair');
     expect(res.body.pair).toHaveProperty('href');
-    expect(res.body.pair).toHaveProperty('input');
-    expect(res.body.pair.input).toHaveProperty('timeout');
-    expect(res.body.pair.input.timeout).toEqual(60);
     expect(res.body.pair).toHaveProperty('status');
     expect(res.body.pair).toHaveProperty('timeRequested');
   });
@@ -194,9 +185,6 @@ describe('actions/', () => {
     expect(res.body.length).toEqual(1);
     expect(res.body[0]).toHaveProperty('pair');
     expect(res.body[0].pair).toHaveProperty('href');
-    expect(res.body[0].pair).toHaveProperty('input');
-    expect(res.body[0].pair.input).toHaveProperty('timeout');
-    expect(res.body[0].pair.input.timeout).toEqual(60);
     expect(res.body[0].pair).toHaveProperty('status');
     expect(res.body[0].pair).toHaveProperty('timeRequested');
 
@@ -210,9 +198,6 @@ describe('actions/', () => {
     expect(res.body.length).toEqual(1);
     expect(res.body[0]).toHaveProperty('pair');
     expect(res.body[0].pair).toHaveProperty('href');
-    expect(res.body[0].pair).toHaveProperty('input');
-    expect(res.body[0].pair.input).toHaveProperty('timeout');
-    expect(res.body[0].pair.input.timeout).toEqual(60);
     expect(res.body[0].pair).toHaveProperty('status');
     expect(res.body[0].pair).toHaveProperty('timeRequested');
 
@@ -225,9 +210,6 @@ describe('actions/', () => {
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty('pair');
     expect(res.body.pair).toHaveProperty('href');
-    expect(res.body.pair).toHaveProperty('input');
-    expect(res.body.pair.input).toHaveProperty('timeout');
-    expect(res.body.pair.input.timeout).toEqual(60);
     expect(res.body.pair).toHaveProperty('status');
     expect(res.body.pair).toHaveProperty('timeRequested');
   });
@@ -347,10 +329,10 @@ describe('actions/', () => {
 
     let res = await chai
       .request(server)
-      .post(Constants.ACTIONS_PATH)
+      .post(`${Constants.ACTIONS_PATH}/unpair`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send({ unpair: { input: { id: thingId } } });
+      .send({ id: thingId });
     expect(res.status).toEqual(201);
 
     res = await chai
@@ -360,9 +342,6 @@ describe('actions/', () => {
       .set(...headerAuth(jwt));
     expect(Array.isArray(res.body)).toBeTruthy();
     expect(res.body[0]).toHaveProperty('unpair');
-    expect(res.body[0].unpair).toHaveProperty('input');
-    expect(res.body[0].unpair.input).toHaveProperty('id');
-    expect(res.body[0].unpair.input.id).toBe('test-nonexistent');
     expect(res.body[0].unpair).toHaveProperty('href');
     expect(res.body[0].unpair).toHaveProperty('status');
     expect(res.body[0].unpair.status).toEqual('completed');

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -614,10 +614,10 @@ describe('things/', function () {
       (async () => {
         const res = await chai
           .request(server)
-          .post(Constants.ACTIONS_PATH)
+          .post(`${Constants.ACTIONS_PATH}/pair`)
           .set('Accept', 'application/json')
           .set(...headerAuth(jwt))
-          .send({ pair: { input: { timeout: 60 } } });
+          .send({ timeout: 60 });
 
         await mockAdapter().addDevice('test-4', makeDescr('test-4'));
         await mockAdapter().addDevice('test-5', makeDescr('test-5'));
@@ -642,10 +642,10 @@ describe('things/', function () {
     // send pair action
     let res = await chai
       .request(server)
-      .post(Constants.ACTIONS_PATH)
+      .post(`${Constants.ACTIONS_PATH}/pair`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send({ pair: { input: { timeout: 60 } } });
+      .send({ timeout: 60 });
     expect(res.status).toEqual(201);
 
     res = await chai
@@ -709,10 +709,10 @@ describe('things/', function () {
     // send pair action
     const pair = await chai
       .request(server)
-      .post(Constants.ACTIONS_PATH)
+      .post(`${Constants.ACTIONS_PATH}/pair`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send({ pair: { input: { timeout: 60 } } });
+      .send({ timeout: 60 });
     expect(pair.status).toEqual(201);
 
     let res = await chai
@@ -750,10 +750,10 @@ describe('things/', function () {
     // send pair action
     const pair = await chai
       .request(server)
-      .post(Constants.ACTIONS_PATH)
+      .post(`${Constants.ACTIONS_PATH}/pair`)
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
-      .send({ pair: { input: { timeout: 60 } } });
+      .send({ timeout: 60 });
     expect(pair.status).toEqual(201);
     await mockAdapter().removeDevice(thingId);
 
@@ -781,10 +781,10 @@ describe('things/', function () {
     mockAdapter().unpairDevice(thingId);
     let res = await chai
       .request(server)
-      .post(Constants.ACTIONS_PATH)
+      .post(`${Constants.ACTIONS_PATH}/pair`)
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
-      .send({ unpair: { input: { id: thingId } } });
+      .send({ id: thingId });
     expect(res.status).toEqual(201);
 
     res = await chai
@@ -1171,10 +1171,10 @@ describe('things/', function () {
       (async () => {
         await chai
           .request(server)
-          .post(Constants.ACTIONS_PATH)
+          .post(`${Constants.ACTIONS_PATH}/pair`)
           .set('Accept', 'application/json')
           .set(...headerAuth(jwt))
-          .send({ pair: { input: { timeout: 60 } } });
+          .send({ timeout: 60 });
 
         let res = await chai
           .request(server)
@@ -1210,7 +1210,7 @@ describe('things/', function () {
     expect(messages[2].messageType).toEqual(Constants.ACTION_STATUS);
     expect(
       (<Record<string, unknown>>(<Record<string, unknown>>messages[2].data).pair).status
-    ).toEqual('created');
+    ).toEqual('pending');
     expect(
       (<Record<string, unknown>>(<Record<string, unknown>>messages[2].data).pair).href
     ).toEqual(actionHref);
@@ -1218,7 +1218,7 @@ describe('things/', function () {
     expect(messages[3].messageType).toEqual(Constants.ACTION_STATUS);
     expect(
       (<Record<string, unknown>>(<Record<string, unknown>>messages[3].data).pair).status
-    ).toEqual('pending');
+    ).toEqual('running');
     expect(
       (<Record<string, unknown>>(<Record<string, unknown>>messages[3].data).pair).href
     ).toEqual(actionHref);
@@ -1260,18 +1260,12 @@ describe('things/', function () {
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
 
-    const actionDescr = {
-      reboot: {
-        input: {},
-      },
-    };
-
     res = await chai
       .request(server)
-      .post(thingBase + Constants.ACTIONS_PATH)
+      .post(`${thingBase}${Constants.ACTIONS_PATH}/reboot`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send(actionDescr);
+      .send();
     expect(res.status).toEqual(201);
 
     res = await chai
@@ -1300,20 +1294,16 @@ describe('things/', function () {
   it('fails to create an action on a nonexistent thing', async () => {
     const thingBase = `${Constants.THINGS_PATH}/nonexistent-thing`;
 
-    const actionDescr = {
-      pair: {
-        input: {
-          timeout: 60,
-        },
-      },
+    const input = {
+      timeout: 60,
     };
 
     const err = await chai
       .request(server)
-      .post(thingBase + Constants.ACTIONS_PATH)
+      .post(`${thingBase}${Constants.ACTIONS_PATH}/pair`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send(actionDescr);
+      .send(input);
     expect(err.status).toEqual(404);
   });
 
@@ -1329,20 +1319,16 @@ describe('things/', function () {
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
 
-    const actionDescr = {
-      pair: {
-        input: {
-          timeout: 60,
-        },
-      },
+    const input = {
+      timeout: 60,
     };
 
     const err = await chai
       .request(server)
-      .post(thingBase + Constants.ACTIONS_PATH)
+      .post(`${thingBase}${Constants.ACTIONS_PATH}/pair`)
       .set(...headerAuth(jwt))
       .set('Accept', 'application/json')
-      .send(actionDescr);
+      .send(input);
     expect(err.status).toEqual(400);
   });
 
@@ -1408,7 +1394,7 @@ describe('things/', function () {
     const created = messages[1];
     expect(created.messageType).toEqual(Constants.ACTION_STATUS);
     expect((<Record<string, unknown>>(<Record<string, unknown>>created.data).pair).status).toEqual(
-      'created'
+      'pending'
     );
 
     const err = messages[2];

--- a/static/js/api.ts
+++ b/static/js/api.ts
@@ -483,13 +483,7 @@ class API {
   }
 
   async startPairing(timeout: number): Promise<Record<string, unknown>> {
-    return (await this.postJson('/actions', {
-      pair: {
-        input: {
-          timeout,
-        },
-      },
-    }))!;
+    return (await this.postJson('/actions/pair', { timeout }))!;
   }
 
   cancelPairing(actionUrl: string): Promise<void> {

--- a/static/js/views/add-thing.js
+++ b/static/js/views/add-thing.js
@@ -93,7 +93,7 @@ const AddThingScreen = {
 
     API.startPairing(timeout)
       .then((json) => {
-        this.actionUrl = json.pair.href;
+        this.actionUrl = json.href;
 
         this.pairingTimeout = setTimeout(() => {
           this.scanStatus.classList.add('hidden');


### PR DESCRIPTION
Closes #2893.

This PR brings the protocol binding of the `invokeaction` operation in line with the [HTTP Basic Profile](https://w3c.github.io/wot-profile/#http-basic-profile) in the latest draft of the W3C WoT Profile specification.

Specifically:
- Aligns the values of the `status` member of the `ActionStatus` object, and extracts them out as constants
- Deprecates the existing use of `POST` on the top level `/actions` endpoint of a Thing, in favour of only allowing a `POST` on `/actions/{actionName}` (the functionality is left in place, but no longer used internally and a deprecation warning is printed on the console)
- Adds the URL of an action resource to the `Location` header of a response to an `invokeaction` request
- Removes object wrappers from various payloads
- Uses the Problem Details format for error messages used by the gateway's own actions
- Updates integration tests to reflect the changes



TODO:
- [x] Implement back end
- [x] Check if front end needs updating
- [x] Extract constants for status member of ActionStatus
- [x] Update format of error member of ActionStatus
- [x] Update integration tests