### PR TITLE
feat(CI): upgrade checkout and setup-node actions of build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           14,
         ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install system dependencies


### PR DESCRIPTION
Successful run - https://github.com/josephyi/gateway/actions/runs/3171386118

I attempted to enable the caching feature, but I think it doesn't like the matrix build. 🤷 