### PR TITLE
Fix various bugs concerning groups UI

### DIFF
--- a/static/css/group.css
+++ b/static/css/group.css
@@ -66,7 +66,7 @@
   transform: rotate(-90deg);
 }
 
-.group.open.drag-target {
+.group.drag-target {
   border: 0.2rem dashed white;
 }
 

--- a/static/css/things.css
+++ b/static/css/things.css
@@ -11,32 +11,25 @@
 
 #things-container {
   position: relative;
-  top: 50%;
-  transform: translateY(-50%);
-  max-height: 100%;
-  display: flex;
-  flex-direction: column;
+  margin: auto;
+  width: calc(100% - 10rem);
 }
 
 #things {
   text-align: center;
   font-size: 1.6rem;
   color: #fff;
-  flex-direction: column;
-  margin: auto;
-  padding-left: 5px;
-  padding-right: 5px;
   min-height: 50px;
+  margin: auto;
   width: calc(100% - 10rem);
 }
 
 #groups {
   text-align: center;
   font-size: 1.6rem;
-  flex-direction: column;
   color: #fff;
-  display: flex;
   margin: auto;
+  width: calc(100% - 10rem);
 }
 
 #add-button {

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -680,7 +680,7 @@ class Thing {
     e.stopPropagation();
 
     const dragNode = document.getElementById(e.dataTransfer.getData('text'));
-    if (!dragNode) {
+    if (!dragNode || dragNode == this.element) {
       return;
     }
 


### PR DESCRIPTION
This fixes:
- The first/last thing of a group / of the ungrouped things disappearing when being dropped on itself (Closes #2940)
- Overlapping things and groups when actually scrolling should take place. As a part of this, groups are fixed-width now.