### PR TITLE
Use docker hub password and add manual trigger

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - README.docker.md
       - .github/workflows/dockerhub-description.yml
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,6 +18,6 @@ jobs:
         uses: peter-evans/dockerhub-description@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_REAL_PASSWORD }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           repository: webthingsio/gateway
           readme-filepath: ./README.docker.md


### PR DESCRIPTION
@benfrancis
I assume that `DOCKER_HUB_REAL_PASSWORD` was the actual docker hub user password.
Maybe this was necessary to update the description.
We can use the existing access token for this.
I also added a manual trigger for the workflow.