### PR TITLE
Don't try to install npm incompatible with node 10 - closes #2994

### DIFF
--- a/image/stage3/01-install-deps/01-run-chroot.sh
+++ b/image/stage3/01-install-deps/01-run-chroot.sh
@@ -28,7 +28,6 @@ nvm_get_arch() {
 # Install node
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
-nvm install-latest-npm
 
 # Allow node to use the Bluetooth adapter
 sudo setcap cap_net_raw+eip $(eval readlink -f $(which node))


### PR DESCRIPTION
`$nvm install-latest-npm` tries to install npm 9.x, which is not compatible with node 10, causing bug #2994. Removing this line means nvm installs a npm 6.x instead, which is compatible.