### PR TITLE
Add a pre-release workflow - fixes #2987

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,9 +1,10 @@
-name: Build and push release images
+name: Build and push pre-release images
 
 on:
   push:
     tags:
-    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
 
 jobs:
   create-release:
@@ -39,7 +40,7 @@ jobs:
           publish: true
           imageName: webthingsio/gateway
           platform: linux/amd64,linux/arm/v7,linux/arm64
-          tag: latest,${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
           dockerUser: ${{ secrets.DOCKER_HUB_USER }}
           dockerPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}
 


### PR DESCRIPTION
This is a proposed workflow for pre-release images, which fixes #2987.

To use this workflow you create a semver style tag with a suffix of `-alpha` or `-beta` followed by a dot and then a number. E.g. `1.0.1-alpha.1` or `1.0.1-beta.2`.

The only differences between this workflow and the "release" workflow are:
1. It's only triggered by tags with an alpha or beta pre-release suffix as described above, and not by production release tags like `1.0.1`
2. It still pushes a built image to DockerHub (with the pre-release suffix in its name), but it doesn't reset the `latest` tag to the pre-release image