### PR TITLE
Fix extraction of OTA assets during build - fixes #3010

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install qemu
         run: |
           sudo apt update
-          sudo apt install -y qemu qemu-user-static binfmt-support --no-install-recommends
+          sudo apt install -y qemu qemu-user-static binfmt-support kpartx --no-install-recommends
       - name: Setup qemu-user-static
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Build the image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install qemu
         run: |
           sudo apt update
-          sudo apt install -y qemu qemu-user-static binfmt-support --no-install-recommends
+          sudo apt install -y qemu qemu-user-static binfmt-support kpartx --no-install-recommends
       - name: Setup qemu-user-static
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Build the image


### PR DESCRIPTION
Fixes #3010

This PR extracts the built gateway directory (used to generate the OTA update assets) from the built .img.zip file, rather than the working directory of the docker container (which is no longer available after the build has completed).

The one downside of this approach is that kpartx (and mount) require root privileges. That's not a problem in CI where the GitHub VM has password-less sudo, but it might be a bit annoying when running the script locally since you may be prompted to enter your password in order to complete the last few lines of the script (which may be over an hour into the build process).