### PR TITLE
Fix npm version after OTA update and bump version - closes #3021

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "description": "Web of Things gateway",
   "main": "build/app.js",
   "scripts": {

--- a/tools/pre-upgrade.sh
+++ b/tools/pre-upgrade.sh
@@ -15,7 +15,6 @@ fi
 nvm install
 nvm use
 nvm alias default node
-nvm install-latest-npm
 
 # Clean up the nvm cache to free some space
 nvm cache clear


### PR DESCRIPTION
This was already [fixed](https://github.com/WebThingsIO/gateway/pull/3002) in the main build, but turns it out it needed fixing separately for OTA updates.