### PR TITLE
Standardise `@context` of Thing Descriptions - closes #2809

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,6 +82,7 @@ export enum LogSeverity {
   PROMPT = 4,
 }
 
+// Thing description things
 export enum WoTOperation {
   READ_ALL_PROPERTIES = 'readallproperties',
   WRITE_MULTIPLE_PROPERTIES = 'writemultipleproperties',
@@ -89,13 +90,18 @@ export enum WoTOperation {
   UNSUBSCRIBE_ALL_EVENTS = 'unsubscribeallevents',
   QUERY_ALL_ACTIONS = 'queryallactions',
 }
-
 export enum ActionStatusValues {
   PENDING = 'pending',
   RUNNING = 'running',
   COMPLETED = 'completed',
   FAILED = 'failed',
 }
+export const MOZ_IOT_CONTEXT = 'https://iot.mozilla.org/schemas';
+export const WEBTHINGS_CONTEXT = 'https://webthings.io/schemas';
+export const WOT_TD_NS_CONTEXT = 'http://www.w3.org/ns/td';
+export const WOT_TD_1_CONTEXT = 'https://www.w3.org/2019/wot/td/v1';
+export const WOT_TD_1_1_CONTEXT = 'https://www.w3.org/2022/wot/td/v1.1';
+export const DEFAULT_CONTEXT = [WOT_TD_1_1_CONTEXT, WEBTHINGS_CONTEXT];
 
 export interface LogMessage {
   severity: LogSeverity;

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -34,7 +34,7 @@ export interface Router {
 export interface ThingDescription {
   id: string;
   title: string;
-  '@context': string;
+  '@context': string | string[];
   '@type': string[];
   description: string;
   base: string;
@@ -79,7 +79,7 @@ export default class Thing extends EventEmitter {
 
   private title: string;
 
-  private '@context': string;
+  private '@context': string | string[];
 
   private '@type': string[];
 
@@ -133,7 +133,11 @@ export default class Thing extends EventEmitter {
     // Parse the Thing Description
     this.id = id;
     this.title = description.title || (<Record<string, string>>(<unknown>description)).name || '';
-    this['@context'] = description['@context'] || 'https://webthings.io/schemas';
+    if (description['@context']) {
+      this['@context'] = Utils.standardizeContext(description['@context']);
+    } else {
+      this['@context'] = Constants.DEFAULT_CONTEXT;
+    }
     this['@type'] = description['@type'] || [];
     this.description = description.description || '';
     this.href = `${Constants.THINGS_PATH}/${encodeURIComponent(this.id)}`;
@@ -707,7 +711,11 @@ export default class Thing extends EventEmitter {
     const oldDescription = JSON.stringify(this.getDescription());
 
     // Update @context
-    this['@context'] = description['@context'] || 'https://webthings.io/schemas';
+    if (description['@context']) {
+      this['@context'] = Utils.standardizeContext(description['@context']);
+    } else {
+      this['@context'] = Constants.DEFAULT_CONTEXT;
+    }
 
     // Update @type
     this['@type'] = description['@type'] || [];

--- a/src/plugin/device-proxy.ts
+++ b/src/plugin/device-proxy.ts
@@ -31,7 +31,7 @@ export default class DeviceProxy extends Device {
     super(adapter, deviceDict.id);
 
     this.setTitle(deviceDict.title ?? '');
-    this['@context'] = deviceDict['@context'] || 'https://webthings.io/schemas';
+    this['@context'] = deviceDict['@context'] || Constants.DEFAULT_CONTEXT;
     this['@type'] = deviceDict['@type'] || [];
     this.setDescription(deviceDict.description ?? '');
     (<{ links: Link[] }>(<unknown>this)).links = deviceDict.links || [];

--- a/src/test/browser/things-view/thing-test.ts
+++ b/src/test/browser/things-view/thing-test.ts
@@ -14,7 +14,7 @@ describe('Thing', () => {
     const desc = {
       id: 'UnknownThing',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': [],
       properties: {
         numberProp: {
@@ -114,7 +114,7 @@ describe('Thing', () => {
     const desc = {
       id: 'spacedPropertyThings',
       title: 'battery sensor',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': [],
       properties: {
         'spaced number': {
@@ -175,7 +175,7 @@ describe('Thing', () => {
     const desc = {
       id: 'UnknownThing',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': [],
       properties: {
         rejectPropertyNum: {
@@ -258,7 +258,7 @@ describe('Thing', () => {
     const desc = {
       id: 'onOffLight',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['Light', 'OnOffSwitch'],
       properties: {
         power: {
@@ -299,7 +299,7 @@ describe('Thing', () => {
     const desc = {
       id: 'onOffSwitch',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['OnOffSwitch'],
       properties: {
         power: {
@@ -341,7 +341,7 @@ describe('Thing', () => {
     const desc = {
       id: 'dimmableLight',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['Light', 'OnOffSwitch'],
       properties: {
         power: {
@@ -435,7 +435,7 @@ describe('Thing', () => {
     const desc = {
       id: 'onOffColorLight',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['Light', 'ColorControl', 'OnOffSwitch'],
       properties: {
         power: {
@@ -511,7 +511,7 @@ describe('Thing', () => {
     const desc = {
       id: 'dimmableColorLight',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['Light', 'ColorControl', 'OnOffSwitch'],
       properties: {
         power: {
@@ -617,7 +617,7 @@ describe('Thing', () => {
     const desc = {
       id: 'multiLevelSwitch',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['MultiLevelSwitch', 'OnOffSwitch'],
       properties: {
         power: {
@@ -711,7 +711,7 @@ describe('Thing', () => {
     const desc = {
       id: 'smartPlug',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['SmartPlug', 'EnergyMonitor', 'MultiLevelSwitch', 'OnOffSwitch'],
       properties: {
         power: {
@@ -873,7 +873,7 @@ describe('Thing', () => {
     const desc = {
       id: 'binarySensor',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['BinarySensor'],
       properties: {
         active: {
@@ -911,7 +911,7 @@ describe('Thing', () => {
     const desc = {
       id: 'multiLevelSensor',
       title: 'foofoo',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['MultiLevelSensor'],
       properties: {
         active: {
@@ -956,7 +956,7 @@ describe('Thing', () => {
     const desc = {
       id: 'humiditySensor',
       title: 'Humidity',
-      '@context': 'https://webthings.io/schemas',
+      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
       '@type': ['HumiditySensor'],
       properties: {
         humidity: {
@@ -1009,7 +1009,7 @@ describe('Thing', () => {
       const desc = {
         id: 'Camera',
         title: 'Camera',
-        '@context': 'https://webthings.io/schemas',
+        '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
         '@type': ['Camera'],
         properties: {
           photo: {
@@ -1059,7 +1059,7 @@ describe('Thing', () => {
       const desc = {
         id: 'VideoCamera',
         title: 'VideoCamera',
-        '@context': 'https://webthings.io/schemas',
+        '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
         '@type': ['VideoCamera'],
         properties: {
           video: {

--- a/src/test/integration/actions-test.ts
+++ b/src/test/integration/actions-test.ts
@@ -8,7 +8,7 @@ describe('actions/', () => {
   const thingLight = {
     id: 'light',
     title: 'light',
-    '@context': 'https://webthings.io/schemas',
+    '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
     '@type': ['OnOffSwitch', 'Light'],
     properties: {
       power: {

--- a/src/test/integration/logs-test.ts
+++ b/src/test/integration/logs-test.ts
@@ -7,7 +7,7 @@ import sleep from '../../sleep';
 const thingLight1 = {
   id: 'light1',
   title: 'light1',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     on: {

--- a/src/test/integration/oauth-test.ts
+++ b/src/test/integration/oauth-test.ts
@@ -19,7 +19,7 @@ const CLIENT_SERVER_PORT = 31338;
 const TEST_THING = {
   id: 'test-1',
   title: 'kitchen',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     power: {

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -12,7 +12,7 @@ import Events from '../../models/events';
 const TEST_THING = {
   id: 'test-1',
   title: 'test-1',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     power: {
@@ -31,7 +31,7 @@ const TEST_THING = {
 const VALIDATION_THING = {
   id: 'validation-1',
   title: 'validation-1',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   properties: {
     readOnlyProp: {
       type: 'boolean',
@@ -62,7 +62,7 @@ const VALIDATION_THING = {
 const EVENT_THING = {
   id: 'event-thing1',
   title: 'Event Thing',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   events: {
     overheated: {
       type: 'number',
@@ -74,7 +74,7 @@ const EVENT_THING = {
 const piDescr = {
   id: 'pi-1',
   title: 'pi-1',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     power: {

--- a/src/test/rules-engine/index-test.ts
+++ b/src/test/rules-engine/index-test.ts
@@ -11,7 +11,7 @@ const thingLight1 = {
   id: 'light1',
   title: 'light1',
   type: 'onOffSwitch',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     on: { type: 'boolean', value: false },
@@ -35,7 +35,7 @@ const thingLight2 = {
   id: 'light2',
   title: 'light2',
   type: 'onOffSwitch',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     on: { type: 'boolean', value: false },
@@ -49,7 +49,7 @@ const thingLight3 = {
   id: 'light3',
   title: 'light3',
   type: 'onOffSwitch',
-  '@context': 'https://webthings.io/schemas',
+  '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
   properties: {
     on: { type: 'boolean', value: false },


### PR DESCRIPTION
This PR makes sure that all Thing Descriptions exposed by the gateway have both the W3C WoT TD 1.1 and WebThings JSON-LD contexts, in order to work towards W3C compliance. It:

1. Makes sure the `@context` is an array
2. Removes the legacy `iot.mozilla.org/schemas` context if used
3. Makes sure both `https://www.w3.org/2022/wot/td/v1.1` and `https://webthings.io/schemas` are present in the array, and if not adds the W3C context to the start and/or adds the WebThings context to the end of the array. E.g.

```json
"@context": [
  "https://www.w3.org/2022/wot/td/v1.1",
  "https://webthings.io/schemas",
]
```

I had written some code to migrate existing Thing Descriptions in the gateway's database, so that they don't have to be modified at runtime every time they are read, but it turned out that code was redundant. Those Thing Descriptions already get updated on startup as a side effect of the `updateFromDescription()` method being called for every existing device when handling `deviceAdded` messages from adapters. I don't think this is necessarily desirable, so I plan to revisit this in a follow-up and figure out what's going on there.

Note: Currently the gateway only supports an array of strings in the `@context`, not maps which define JSON-LD prefixes. That feature is planned for later, when we'll ideally also [add prefixes to all non-standard members](https://github.com/WebThingsIO/gateway/issues/1919).

TODO:
- [x] Remove legacy context
- [x] Add W3C context
- [x] Add WebThings context
- [x] ~~Migrate old Thing Descriptions~~
- [x] Fix integration tests