### PR TITLE
Bump gateway-addon-node and gateway-addon-python and set gateway version to 1.1.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7490,9 +7490,9 @@
       "dev": true
     },
     "gateway-addon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gateway-addon/-/gateway-addon-1.1.0.tgz",
-      "integrity": "sha512-VilhBg5jF3/wEScsdgA/vHM9h34IeVhwhu54ub/AcClfgr4pAzcXq1tvNFNZYUg8sRzRQu9qI4OROs61kaAgfg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gateway-addon/-/gateway-addon-1.1.1.tgz",
+      "integrity": "sha512-zNNZ5pzPS6+vyfSn95o6+AZh/HRXQQdFxyN3Ta0t0PfO8RtXaUG97f9klns/B2ETAn4RcWJziuF0OqsaxdkNlw==",
       "requires": {
         "ajv": "^7.0.4",
         "sqlite3": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-beta.1",
   "description": "Web of Things gateway",
   "main": "build/app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "express-rate-limit": "^5.2.6",
     "express-ws": "^4.0.0",
     "find": "^0.3.0",
-    "gateway-addon": "^1.1.0",
+    "gateway-addon": "^1.1.1",
     "glob-to-regexp": "^0.4.1",
     "http-proxy": "^1.18.1",
     "@types/jest": "^27.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/WebThingsIO/gateway-addon-python@v1.1.0#egg=gateway_addon
+git+https://github.com/WebThingsIO/gateway-addon-python@v1.1.1#egg=gateway_addon


### PR DESCRIPTION
This PR is hopefully the last step in fixing the issue with invisible properties in the 1.1 release.

Fixes #3038.

After this I hope to tag a 1.1.0-beta.1 release and push out another pre-release update.