### PR TITLE
Screw you TypeScript (1.1) - closes #3046

### DIFF
--- a/src/addon-utils.ts
+++ b/src/addon-utils.ts
@@ -235,21 +235,26 @@ function loadManifestJson(packageId: string): [Record<string, unknown>, Record<s
   let min = manifest.gateway_specific_settings.webthings.strict_min_version;
   let max = manifest.gateway_specific_settings.webthings.strict_max_version;
 
+  const gatewayVersion = semver.coerce(pkg.version);
+  if (gatewayVersion === null) {
+    throw new Error(`Unable to compare with non-semver gateway version ${pkg.version}`);
+  }
+
   if (typeof min === 'string' && min !== '*') {
     min = semver.coerce(min);
-    if (semver.lt(pkg.version, min)) {
+    if (semver.lt(gatewayVersion, min)) {
       throw new Error(
         // eslint-disable-next-line max-len
-        `Gateway version ${pkg.version} is lower than minimum version ${min} supported by add-on ${packageId}`
+        `Gateway version ${gatewayVersion} is lower than minimum version ${min} supported by add-on ${packageId}`
       );
     }
   }
   if (typeof max === 'string' && max !== '*') {
     max = semver.coerce(max);
-    if (semver.gt(pkg.version, max)) {
+    if (semver.gt(gatewayVersion, max)) {
       throw new Error(
         // eslint-disable-next-line max-len
-        `Gateway version ${pkg.version} is higher than maximum version ${max} supported by add-on ${packageId}`
+        `Gateway version ${gatewayVersion} is higher than maximum version ${max} supported by add-on ${packageId}`
       );
     }
   }

--- a/src/addon-utils.ts
+++ b/src/addon-utils.ts
@@ -82,7 +82,8 @@ function validateObject(
  * @returns {string|null} Error string, or null if no error.
  */
 function validateManifestJson(manifest: Record<string, unknown>): string | null {
-  const manifestTemplate = {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const manifestTemplate: Record<string, any> = {
     author: '',
     description: '',
     gateway_specific_settings: {
@@ -122,9 +123,7 @@ function validateManifestJson(manifest: Record<string, unknown>): string | null 
   ) {
     // If we're not using in-process plugins, and this is not an extension,
     // then we also need the exec keyword to exist.
-    (<Record<string, unknown>>(
-      (<Record<string, unknown>>manifest.gateway_specific_settings).webthings
-    )).exec = '';
+    manifestTemplate.gateway_specific_settings.webthings.exec = '';
   }
 
   return validateObject('', manifest, manifestTemplate);

--- a/src/test/integration/addons-test.ts
+++ b/src/test/integration/addons-test.ts
@@ -401,7 +401,7 @@ describe('addons', () => {
     const manifest: Record<string, unknown> = copyManifest(testManifestJson);
     (<Record<string, unknown>>(
       (<Record<string, unknown>>manifest.gateway_specific_settings).webthings
-    )).strict_min_version = semver.inc(pkg.version, 'minor')!;
+    )).strict_min_version = semver.inc(pkg.version, 'major')!;
     expect(await loadSettingsAdapterWithManifestJson(manifest)).toBeTruthy();
   });
 


### PR DESCRIPTION
https://github.com/WebThingsIO/gateway/pull/3040 appears to have caused a regression (#3046) which breaks all adapter add-ons and prevents users from adding or using any things.

Here is a version of that patch which is not completely typesafe, but has the benefit that it works.

closes #3046 and closes #3045