### PR TITLE
Standardise event data schemas - closes #2810

### DIFF
--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -24,6 +24,7 @@ import {
 } from 'gateway-addon/lib/schema';
 import Action from './action';
 import Event from './event';
+import * as Utils from '../utils';
 
 export interface Router {
   addProxyServer: (thingId: string, server: string) => void;
@@ -296,11 +297,10 @@ export default class Thing extends EventEmitter {
     }
 
     for (const eventName in this.events) {
-      const event = this.events[eventName];
+      let event = this.events[eventName];
 
-      if (event.hasOwnProperty('href')) {
-        delete event.href;
-      }
+      // Move legacy event data schema to standard location and remove href if present
+      event = Utils.standardizeEventDescription(event);
 
       if (event.forms) {
         event.forms = event.forms.map((form) => {
@@ -805,11 +805,10 @@ export default class Thing extends EventEmitter {
     // Update events
     this.events = description.events || {};
     for (const eventName in this.events) {
-      const event = this.events[eventName];
+      let event = this.events[eventName];
 
-      if (event.hasOwnProperty('href')) {
-        delete event.href;
-      }
+      // Move legacy event data schema to standard location and remove href if present
+      event = Utils.standardizeEventDescription(event);
 
       if (event.forms) {
         event.forms = event.forms.map((form) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import * as Platform from './platform';
 import pkg from './package.json';
+import { Event as EventSchema } from 'gateway-addon/lib/schema';
 
 /**
  * Compute a SHA-256 checksum of a file.
@@ -87,4 +88,53 @@ export function isW3CThingDescription(thingDescription: {
   }
 
   return false;
+}
+
+/**
+ * Convert event descriptions from the legacy format in the Web Thing API
+ * (https://webthings.io/api/#event-object) to the W3C WoT TD standard format
+ * (https://w3c.github.io/wot-thing-description/#eventaffordance).
+ *
+ * @param {EventSchema} description
+ * @returns {EventSchema}
+ */
+export function standardizeEventDescription(description: EventSchema): EventSchema {
+  if (description.hasOwnProperty('href')) {
+    delete description.href;
+    console.warn('The href member of event descriptions is deprecated');
+  }
+  description.data = description.data || {};
+  if (description.hasOwnProperty('type')) {
+    description.data.type = description.type;
+    delete description.type;
+    console.warn('The type member of event descriptions is deprecated, please use data.type');
+  }
+  if (description.hasOwnProperty('unit')) {
+    description.data.unit = description.unit;
+    delete description.unit;
+    console.warn('The unit member of event descriptions is deprecated, please use data.unit');
+  }
+  if (description.hasOwnProperty('minimum')) {
+    description.data.minimum = description.minimum;
+    delete description.minimum;
+    console.warn('The minimum member of event descriptions is deprecated, please use data.minimum');
+  }
+  if (description.hasOwnProperty('maximum')) {
+    description.data.maximum = description.maximum;
+    delete description.maximum;
+    console.warn('The maximum member of event descriptions is deprecated, please use data.maximum');
+  }
+  if (description.hasOwnProperty('multipleOf')) {
+    description.data.multipleOf = description.multipleOf;
+    delete description.multipleOf;
+    console.warn(
+      'The multipleOf member of event descriptions is deprecated, please use data.multipleOf'
+    );
+  }
+  if (description.hasOwnProperty('enum')) {
+    description.data.enum = description.enum;
+    delete description.enum;
+    console.warn('The enum member of event descriptions is deprecated, please use data.enum');
+  }
+  return description;
 }


### PR DESCRIPTION
This PR moves the data schema members of an event description inside a wrapper called `data`.

The purpose of this is to convert event descriptions from the legacy [Event](https://webthings.io/api/#event-object) format in the Web Thing API  to the  [EventAffordance](https://w3c.github.io/wot-thing-description/#eventaffordance) format in the W3C WoT Thing Description specification.

For example:

```json
"overheated": {
  "title": "Overheated",
  "description": "The lamp has exceeded its safe operating temperature",
  "@type": "OverheatedEvent",
  "type": "number",
  "unit": "degree celsius",
  "forms": [{"href": "/things/lamp/events/overheated"}]
}
```

would become:

```json
"overheated": {
  "title": "Overheated",
  "description": "The lamp has exceeded its safe operating temperature",
  "@type": "OverheatedEvent",
  "data": {
    "type": "number",
    "unit": "degree celsius",
  }
  "forms": [{"href": "/things/lamp/events/overheated"}]
}
```

This is necessary to be backwards compatible with add-ons which provide the old format. Deprecation warnings are printed on the console to advise add-on developers.

closes #2810.