### PR TITLE
Deactivate broken update script to fix docker containers

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -55,7 +55,7 @@ else
         "$(< "${WEBTHINGS_HOME}/.node_version")" != "${_node_version}" ]]; then
     cd "${HOME}/webthings/gateway"
     mkdir -p "${WEBTHINGS_HOME}/config"
-    ./tools/update-addons.sh
+    # ./tools/update-addons.sh
     cd -
     echo "${_node_version}" > "${WEBTHINGS_HOME}/.node_version"
   fi


### PR DESCRIPTION
Fixes #3066 #3065 #3043

The update-addons.sh does two things:
- Run the [migrate](https://github.com/WebThingsIO/gateway/blob/master/src/migrate.ts) script
- Call the [updateAddons](https://github.com/WebThingsIO/gateway/blob/c378371d9f0dc5796287d469b8d67b5a6b56df07/src/addon-manager.ts#L1209) method

I'm not sure if we even still need the migrate script and the `updateAddons` method is called after the start anyways.