### PR TITLE
Bugfix for NaN issue

### DIFF
--- a/static/js/logs/log.js
+++ b/static/js/logs/log.js
@@ -209,7 +209,7 @@ class Log {
       let newStart = newEnd - this.weekDropdown.value;
       if (newStart < this.logStart.getTime()) {
         newStart = this.logStart.getTime();
-        newEnd = newStart + this.weekDropdown.value;
+        newEnd = newStart + parseInt(this.weekDropdown.value);
       }
       this.start = new Date(newStart);
       this.end = new Date(newEnd);

--- a/static/js/logs/log.js
+++ b/static/js/logs/log.js
@@ -206,7 +206,7 @@ class Log {
     }
     const onChange = () => {
       let newEnd = this.end.getTime();
-      let newStart = newEnd - this.weekDropdown.value;
+      let newStart = newEnd - parseInt(this.weekDropdown.value);
       if (newStart < this.logStart.getTime()) {
         newStart = this.logStart.getTime();
         newEnd = newStart + parseInt(this.weekDropdown.value);


### PR DESCRIPTION
- select small part of log manually
- select 'week' from the dropdown

In some cases this led to an error. This fixes the `NaN` issues from the int becoming a string.