### PR TITLE
Add `profile` member to Thing Descriptions - closes #2909

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,12 +100,18 @@ export enum ActionStatusValues {
   COMPLETED = 'completed',
   FAILED = 'failed',
 }
+
+// Contexts
 export const MOZ_IOT_CONTEXT = 'https://iot.mozilla.org/schemas';
 export const WEBTHINGS_CONTEXT = 'https://webthings.io/schemas';
 export const WOT_TD_NS_CONTEXT = 'http://www.w3.org/ns/td';
 export const WOT_TD_1_CONTEXT = 'https://www.w3.org/2019/wot/td/v1';
 export const WOT_TD_1_1_CONTEXT = 'https://www.w3.org/2022/wot/td/v1.1';
 export const DEFAULT_CONTEXT = [WOT_TD_1_1_CONTEXT, WEBTHINGS_CONTEXT];
+
+// Profiles
+export const WOT_HTTP_BASIC_PROFILE = 'https://www.w3.org/2022/wot/profile/http-basic/v1';
+export const WOT_HTTP_SSE_PROFILE = 'https://www.w3.org/2022/wot/profile/http-sse/v1';
 
 export interface LogMessage {
   severity: LogSeverity;

--- a/src/test/integration/things-test.ts
+++ b/src/test/integration/things-test.ts
@@ -31,6 +31,10 @@ const piDescr = {
   title: 'pi-1',
   '@context': ['https://www.w3.org/2022/wot/td/v1.1', 'https://webthings.io/schemas'],
   '@type': ['OnOffSwitch'],
+  profile: [
+    'https://www.w3.org/2022/wot/profile/http-basic/v1',
+    'https://www.w3.org/2022/wot/profile/http-sse/v1',
+  ],
   properties: {
     power: {
       '@type': 'OnOffProperty',


### PR DESCRIPTION
This PR adds the `profile` member to Thing Descriptions as per the W3C [WoT Thing Description 1.1](https://www.w3.org/TR/wot-thing-description11/) and [WoT Profile 1.0](https://www.w3.org/TR/wot-profile/) specifications.

Once #3074 and this PR have landed, web things exposed by WebThings Gateway should be conformant with the [HTTP Basic Profile](https://www.w3.org/TR/wot-profile/#http-basic-profile) and [HTTP SSE Profile](https://www.w3.org/TR/wot-profile/#sec-http-sse-profile) from the latest Working Draft of the W3C WoT Profile specification.

There may still be a few niggles to iron out, but this is a big milestone.