### PR TITLE
Disable browser tests until they can be fixed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
     '/src/',
+    '<rootDir>/test/browser/', // https://github.com/WebThingsIO/gateway/issues/3007
   ],
   transform: {
     '\\.js$': 'babel-jest',


### PR DESCRIPTION
I think it might be time to disable the browser tests until they can be made reliable enough to be useful.

See #3007.