### PR TITLE
Refine groups API - fixes #2939

### DIFF
--- a/src/controllers/groups_controller.ts
+++ b/src/controllers/groups_controller.ts
@@ -153,7 +153,7 @@ function build(): express.Router {
     Things.getThingDescriptions(request.get('Host'), request.secure)
       .then((things) => {
         const filteredThings = Array.from(things.values()).filter((thing) => {
-          return thing.group_id == id;
+          return thing.groupId == id;
         });
         response.status(200).json(filteredThings);
       })

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -55,7 +55,7 @@ export interface ThingDescription {
   iconData: IconData;
   security: string;
   securityDefinitions: SecurityDefinition;
-  group_id: string | null;
+  groupId: string | null;
 }
 
 interface IconData {
@@ -116,7 +116,7 @@ export default class Thing extends EventEmitter {
 
   private iconHref: string | null;
 
-  private group_id: string | null;
+  private groupId: string | null;
 
   /**
    * Thing constructor.
@@ -369,7 +369,7 @@ export default class Thing extends EventEmitter {
       this.setIcon(description.iconData, false);
     }
 
-    this.group_id = description.group_id || null;
+    this.groupId = description.groupId || null;
   }
 
   getId(): string {
@@ -385,7 +385,7 @@ export default class Thing extends EventEmitter {
   }
 
   getGroup(): string | null {
-    return this.group_id;
+    return this.groupId;
   }
 
   getHref(): string {
@@ -552,11 +552,11 @@ export default class Thing extends EventEmitter {
   /**
    * Set the group for a Thing in the overview.
    *
-   * @param {string} group_id ID of the group
+   * @param {string} groupId ID of the group
    * @return {Promise} A promise which resolves with the description set.
    */
-  setGroup(group_id: string | null): Promise<ThingDescription> {
-    this.group_id = group_id;
+  setGroup(groupId: string | null): Promise<ThingDescription> {
+    this.groupId = groupId;
     return Database.updateThing(this.id, this.getDescription()).then((descr) => {
       return descr;
     });
@@ -664,7 +664,7 @@ export default class Thing extends EventEmitter {
       layoutIndex: this.layoutIndex,
       selectedCapability: this.selectedCapability,
       iconHref: this.iconHref,
-      group_id: this.group_id,
+      groupId: this.groupId,
     } as ThingDescription;
 
     if (typeof reqHost !== 'undefined') {

--- a/src/models/things.ts
+++ b/src/models/things.ts
@@ -361,16 +361,16 @@ class Things extends EventEmitter {
    * Set the group for a Thing in the overview.
    *
    * @param {number} thing The thing.
-   * @param {string} group_id ID of the group
+   * @param {string} groupId ID of the group
    * @return {Promise} A promise which resolves with the description set.
    */
-  async setThingGroup(thing: Thing, group_id: string | null, emitModified = true): Promise<void> {
-    if (!group_id) {
-      group_id = null;
+  async setThingGroup(thing: Thing, groupId: string | null, emitModified = true): Promise<void> {
+    if (!groupId) {
+      groupId = null;
     }
 
     await this.setThingLayoutIndex(thing, Infinity, false);
-    await thing.setGroup(group_id);
+    await thing.setGroup(groupId);
     const index =
       Array.from(this.things.values()).filter((t) => t.getGroup() == thing.getGroup()).length - 1;
     await thing.setLayoutIndex(index);
@@ -384,19 +384,19 @@ class Things extends EventEmitter {
    * Set the group and layout index for a Thing in the overview.
    *
    * @param {number} thing The thing.
-   * @param {string} group_id ID of the group
+   * @param {string} groupId ID of the group
    * @param {number} index The new layout index.
    * @return {Promise} A promise which resolves with the description set.
    */
   async setThingGroupAndLayoutIndex(
     thing: Thing,
-    group_id: string | null,
+    groupId: string | null,
     index: number
   ): Promise<void> {
-    if (!group_id) {
-      group_id = null;
+    if (!groupId) {
+      groupId = null;
     }
-    await this.setThingGroup(thing, group_id, false);
+    await this.setThingGroup(thing, groupId, false);
     await this.setThingLayoutIndex(thing, index, false);
     this.emit(Constants.LAYOUT_MODIFIED);
   }
@@ -415,13 +415,13 @@ class Things extends EventEmitter {
       }
 
       const index = thing.getLayoutIndex();
-      const group_id = thing.getGroup();
+      const groupId = thing.getGroup();
 
       thing.remove();
       this.things.delete(id);
 
       Array.from(this.things.values())
-        .filter((t) => t.getGroup() == group_id)
+        .filter((t) => t.getGroup() == groupId)
         .forEach((t) => {
           if (t.getLayoutIndex() > index) {
             t.setLayoutIndex(t.getLayoutIndex() - 1);

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -40,7 +40,7 @@ class ThingModel extends Model {
     }
 
     // Parse group id of Thing
-    this.group_id = description.group_id;
+    this.groupId = description.groupId;
 
     // Parse properties and events URLs
     for (const form of description.forms) {

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -95,8 +95,8 @@ class Thing {
       this.container = document.getElementById('floorplan');
       this.x = description.floorplanX;
       this.y = description.floorplanY;
-    } else if (this.model.group_id) {
-      this.container = document.querySelector(`#group-${this.model.group_id}`);
+    } else if (this.model.groupId) {
+      this.container = document.querySelector(`#group-${this.model.groupId}`);
     } else {
       this.container = document.getElementById('things');
     }
@@ -712,7 +712,7 @@ class Thing {
     }
 
     const dragNodeId = Utils.unescapeHtml(dragNode.id).replace(/^thing-/, '');
-    API.setThingGroupAndLayoutIndex(dragNodeId, this.model.group_id, dropIndex)
+    API.setThingGroupAndLayoutIndex(dragNodeId, this.model.groupId, dropIndex)
       .then(() => {
         App.gatewayModel.refreshThings();
       })


### PR DESCRIPTION
Following my proposal in #2939, all this first PR actually does is to rename `group_id` to `groupId` in Thing Descriptions to make its case consistent with all of the other members (i.e. lower camel case rather than snake case).

A vendor prefix could be done later as part of a wider change in #2832.