### PR TITLE
Don't flash No Devices Yet on page load - closes #3056

### DIFF
--- a/static/js/views/things.js
+++ b/static/js/views/things.js
@@ -145,7 +145,7 @@ const ThingsScreen = {
     App.gatewayModel.unsubscribe(Constants.REFRESH_THINGS, this.refreshThing);
     App.gatewayModel.unsubscribe(Constants.DELETE_THINGS, this.refreshThing);
     App.gatewayModel.subscribe(Constants.DELETE_THINGS, this.refreshThings);
-    App.gatewayModel.subscribe(Constants.REFRESH_THINGS, this.refreshThings, true);
+    App.gatewayModel.subscribe(Constants.REFRESH_THINGS, this.refreshThings);
   },
 
   /**


### PR DESCRIPTION
@tim-hellhake Do you think it's safe to remove this argument to fix bug #3056?

Please see my explanation in the issue.