### PR TITLE
Initial snapcraft.yaml thanks to @ogra1 - closes #2147

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,50 @@
+name: webthings-gateway
+base: core22
+version: '2.0.0'
+summary: WebThings Gateway
+description: |
+  A self-hosted web application for monitoring and controlling a building over
+  the web.
+
+grade: stable
+confinement: strict
+
+apps:
+  webthings-gateway:
+    command: bin/npm --prefix $SNAP/lib/node_modules/webthings-gateway run run-only
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  python-deps:
+    plugin: python
+    source: https://github.com/WebThingsIO/gateway.git
+    python-requirements:
+      - requirements.txt
+  webthings-gateway:
+    plugin: npm
+    source: https://github.com/WebThingsIO/gateway.git
+    after: [ python-deps ]
+    npm-include-node: true
+    npm-node-version: 10.24.1
+    build-environment:
+      - npm_config_unsafe_perm: true
+      - NODE_ENV: dev
+      - CPPFLAGS: "$CPPFLAGS -DPNG_ARM_NEON_OPT=0"
+    build-packages:
+      - build-essential
+      - libbluetooth-dev
+      - libboost-python-dev
+      - libboost-thread-dev
+      - libffi-dev
+      - libglib2.0-dev
+      - libpng-dev
+      - libudev-dev
+      - libusb-1.0-0-dev
+    override-build: |
+      craftctl default
+      npm install --only-dev
+      npm run-script build
+      cp -av build $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/


### PR DESCRIPTION
This is an initial snapcraft.yaml for WebThings Gateway created for us by @ogra1 at Canonical.

This is just a rough first pass and lots of things are expected to be broken, but it should be enough to publish a first edge release of a snap package that installs and starts.