### PR TITLE
Detect if running inside a snap or on Ubuntu Core

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,7 @@ apps:
     plugs:
       - network
       - network-bind
+      - system-observe
 
 parts:
   python-deps:


### PR DESCRIPTION
This is the first step in porting WebThings Gateway to Ubuntu Core.

Ubuntu Core does not ship with the `lsb_release` command so we have to add some snap-specific code to check for the existence of a distro ID in `/var/lib/snapd/hostfs/etc/os-release`, which relates to the host OS. See https://forum.snapcraft.io/t/hosts-lsb-release-but-core-os-release/24351/4