### PR TITLE
Fix pagekite

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,3 +49,8 @@ parts:
       npm install --only-dev
       npm run-script build
       cp -av build $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/
+      # fix wrongly hardcoded /usr/bin/python interpreter in pagekite
+      if [ -e $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/pagekite.py ]; then
+        sed -i 's;#!.*;#! /usr/bin/env python3;' \
+            $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/pagekite.py
+      fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,10 +30,11 @@ parts:
     npm-include-node: true
     npm-node-version: 10.24.1
     build-environment:
-      - npm_config_unsafe_perm: true
-      - NODE_ENV: dev
+      - npm_config_unsafe_perm: "true"
+      - NODE_ENV: "dev"
       - CPPFLAGS: "$CPPFLAGS -DPNG_ARM_NEON_OPT=0"
     build-packages:
+      - autoconf
       - build-essential
       - libbluetooth-dev
       - libboost-python-dev


### PR DESCRIPTION
pagekite hardcodes the /usr/bin/python interpreter which is non-existing on most modern distros (it should be pointing to python2 (unsupported by upstream) or python3 nowadays).

On UbuntuCore specfically the interpreter path should even be provided by the env command since it might actually be shipped inside the snap package itself. 

This PR changes the interpreter line of pagekite.py to follow the modern python rules so it can be used in a snap and on UbuntuCore seamlessly.