### PR TITLE
Fix build and runtime failures of snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,7 @@ parts:
     source: https://github.com/WebThingsIO/gateway.git
     after: [ python-deps ]
     npm-include-node: true
-    npm-node-version: 10.24.1
+    npm-node-version: 12.22.1
     build-environment:
       - npm_config_unsafe_perm: "true"
       - NODE_ENV: "dev"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       - NODE_ENV: "dev"
       - CPPFLAGS: "$CPPFLAGS -DPNG_ARM_NEON_OPT=0"
     build-packages:
-      - autoconf
+      - automake
       - build-essential
       - libbluetooth-dev
       - libboost-python-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
       craftctl default
       npm install --only-dev
       npm run-script build
-      cp -av build $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/
+      cp -avf build $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/
       # fix wrongly hardcoded /usr/bin/python interpreter in pagekite
       if [ -e $CRAFT_PART_INSTALL/lib/node_modules/webthings-gateway/pagekite.py ]; then
         sed -i 's;#!.*;#! /usr/bin/env python3;' \


### PR DESCRIPTION
> BTW these patches would be more useful as pull requests if you're able to create them.

Done! 🫡 

Closes #3171 
Closes #3167 

> WebThings Gateway definitely usually runs under Node.js 10 ... This is really a long way of saying that it shouldn't be necessary to upgrade Node.js from version 10 to version 12 to get the snap to build, because the snap was building locally with Node.js 10 before without a problem.

That's interesting. I'm not familiar enough with Node or JS to explain how that's the case.

> Might there be a reason that local builds of the snap with Node.js 10 were working fine, but remote builds on snapcraft.io are somehow different?

They shouldn't be different. How are you building the snap locally? I'm building with snapcraft 8.x (various versions) with `--use-lxd`, I'm trying now with snapcraft 7.5.5 in a Jammy container with `--destructive-mode` to compare.

(Just ran a build in a Jammy LXD container using snapcraft 7.5.5 with `snapcraft --destructive-mode` and installed the snap with `--dangerous`, I get the same error message of `2024-10-08T21:39:41Z webthings-gateway.webthings-gateway[4792]: ReferenceError: globalThis is not defined`).

The build environment shouldn't really impact this, as this is a runtime problem; indeed, this problem should have always existed, as snapcraft will always fetch the node version you specify (as part of the [npm plugin](https://github.com/canonical/snapcraft/blob/82fa41a2c80075bb851a5f0f046655571ec917cb/snapcraft_legacy/plugins/v2/npm.py#L94)).


> I'm assuming this is intended to fix an error which I also https://github.com/WebThingsIO/gateway/issues/3167#issuecomment-2338597957 with local builds of the snap. 

Indeed it is!

> In that case I found that when I started from a fresh git checkout the error went away.

Does this mean that you are building with `--destructive-mode`?

> Whilst I am OK with the proposed fix, I would prefer to understand the cause of this error. It could be something as simple as the build directory already existing.

The real reason the failure happens is if you build, don't clean, and attempt a rebuild; the file already exists in the target location, and for some reason snapcraft is rerunning the build step for that part again. But `cp` will refuse to overwrite the same file, and returns with `exit 1`; because of that nonzero exit code, snapcraft considers a step to have failed and stops the build.

In this specific instance, overwriting is safe. Generally speaking, overwriting is usually the behavior you would want (for instance, many `Makefile`s will use `cp -f`, `rm -f`, `ln -f`, etc.).