### PR TITLE
Properly compare prerelease versions for add-ons - closes #3181

### DIFF
--- a/src/addon-utils.ts
+++ b/src/addon-utils.ts
@@ -235,13 +235,13 @@ function loadManifestJson(packageId: string): [Record<string, unknown>, Record<s
   let min = manifest.gateway_specific_settings.webthings.strict_min_version;
   let max = manifest.gateway_specific_settings.webthings.strict_max_version;
 
-  const gatewayVersion = semver.coerce(pkg.version);
+  const gatewayVersion = semver.coerce(pkg.version, { includePrerelease: true });
   if (gatewayVersion === null) {
     throw new Error(`Unable to compare with non-semver gateway version ${pkg.version}`);
   }
 
   if (typeof min === 'string' && min !== '*') {
-    min = semver.coerce(min);
+    min = semver.coerce(min, { includePrerelease: true });
     if (semver.lt(gatewayVersion, min)) {
       throw new Error(
         // eslint-disable-next-line max-len
@@ -250,7 +250,7 @@ function loadManifestJson(packageId: string): [Record<string, unknown>, Record<s
     }
   }
   if (typeof max === 'string' && max !== '*') {
-    max = semver.coerce(max);
+    max = semver.coerce(max, { includePrerelease: true });
     if (semver.gt(gatewayVersion, max)) {
       throw new Error(
         // eslint-disable-next-line max-len


### PR DESCRIPTION
Include pre-release strings in semantic versions to make a proper comparison.

closes #3181