### PR TITLE
Give the snap access to serial ports - closes #3152

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is an open source [Web of Things](https://www.w3.org/WoT/) gateway.
 
 - If you have a Rasberry Pi, the easiest way to use the gateway is to [download and flash](http://webthings.io/gateway/) a pre-built software image to an SD card.
 - If you prefer to use Docker, we have a prebuilt Docker image available [here](https://hub.docker.com/r/webthingsio/gateway), for both ARM and amd64. You can also build your own image from this repository.
-- On Ubuntu or Ubuntu Core you can install the experimental [snap package](https://snapcraft.io/webthings-gateway) with `$ snap install webthings-gateway --edge`. (Requires the `system-observe` and `network-manager` interfaces to be connected in order to configure network settings).
+- On Ubuntu or Ubuntu Core you can install the experimental [snap package](https://snapcraft.io/webthings-gateway).
 - Otherwise, you can build WebThings Gateway from source yourself (see below).
 
 ## Documentation

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,36 @@
+A self-hosted web application for monitoring and controlling a building over the web.
+
+**Installation**
+
+On Ubuntu Server/Ubuntu Desktop:
+
+`$ sudo snap install --edge webthings-gateway`
+`$ sudo snap connect webthings-gateway:system-observe`
+`$ sudo snap connect webthings-gateway:hardware-observe`
+`$ sudo snap connect webthings-gateway:network-manager`
+`$ sudo snap set system experimental.hotplug=true`
+`$ sudo snap restart webthings-gateway`
+
+On Ubuntu Core:
+
+`$ snap install --edge webthings-gateway`
+`$ snap install network-manager`
+`$ snap connect webthings-gateway:system-observe`
+`$ snap connect webthings-gateway:hardware-observe`
+`$ snap connect webthings-gateway:network-manager network-manager:service`
+`$ sudo snap set system experimental.hotplug=true`
+`$ snap restart webthings-gateway`
+
+Currently untested on other host operating systems.
+
+To connect a USB dongle:
+
+`$ snap interface serial-port`
+
+(to find the name of the slot automatically created by hotplug, then...)
+
+`$ snap connect webthings-gateway:serial-port snapd:foo`
+
+(where "foo" is the name of the slot)
+
+Note: This snap package is currently experimental and may not yet be fully functional. For manual installation instructions of a stable version please see https://webthings.io/docs/gateway/installation/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,8 @@ apps:
       - network-bind
       - system-observe
       - network-manager
+      - serial-port
+      - hardware-observe
 
 parts:
   python-deps:


### PR DESCRIPTION
This PR adds the `serial-port` and `hardware-observe` plugs to the snap so that it can access serial ports (e.g. for USB dongles).

This requires the user to turn on experimental hotplug support then manually connect the `hardware-observe` interface and manually connect the `serial-port` interface to a slot created by hotplug when they plug in a USB dongle. I have documented this in a new README file for the snap.

Requiring users to manually connect USB dongles on the command line is not an acceptable user experience so I will file a follow up issue to explore a solution to that problem.